### PR TITLE
Remove ghost entity state

### DIFF
--- a/addons/sourcemod/scripting/nt_wincond.sp
+++ b/addons/sourcemod/scripting/nt_wincond.sp
@@ -34,28 +34,20 @@ public Plugin myinfo = {
     url = "https://github.com/Agiel/nt-wincond"
 };
 
-int g_ghostEntity = -1;
-
 public void OnPluginStart() {
-	Handle gd = LoadGameConfigFile("neotokyo/wincond");
-	if (gd == INVALID_HANDLE) {
-		SetFailState("Failed to load GameData");
-	}
-	DynamicDetour dd = DynamicDetour.FromConf(gd, "Fn_CheckWinCondition");
-	if (!dd) {
-		SetFailState("Failed to create dynamic detour");
-	}
-	if (!dd.Enable(Hook_Pre, CheckWinCondition)) {
-		SetFailState("Failed to detour");
-	}
-	delete dd;
-	CloseHandle(gd);
-}
-
-public void OnEntityCreated(int entity, const char[] classname) {
-    if (StrEqual(classname, "weapon_ghost")) {
-        g_ghostEntity = EntIndexToEntRef(entity);
+    Handle gd = LoadGameConfigFile("neotokyo/wincond");
+    if (gd == INVALID_HANDLE) {
+        SetFailState("Failed to load GameData");
     }
+    DynamicDetour dd = DynamicDetour.FromConf(gd, "Fn_CheckWinCondition");
+    if (!dd) {
+        SetFailState("Failed to create dynamic detour");
+    }
+    if (!dd.Enable(Hook_Pre, CheckWinCondition)) {
+        SetFailState("Failed to detour");
+    }
+    delete dd;
+    CloseHandle(gd);
 }
 
 void EndRound(int gameHud) {
@@ -181,56 +173,77 @@ bool CheckEliminationOrTimeout() {
     return false;
 }
 
+bool IsGhostCarrier(int client)
+{
+    static Handle call = INVALID_HANDLE;
+    if (call == INVALID_HANDLE) {
+        StartPrepSDKCall(SDKCall_Player);
+        PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
+        PrepSDKCall_SetAddress(view_as<Address>(0x222F25C0));
+        call = EndPrepSDKCall();
+        if (call == INVALID_HANDLE) {
+            SetFailState("Failed to prepare SDK call");
+        }
+    }
+    return SDKCall(call, client);
+}
+
 bool CheckGhostCap() {
     int numGhosts = LoadFromAddress(view_as<Address>(0x225443B8), NumberType_Int32);
     int numCapZones = LoadFromAddress(view_as<Address>(0x22542740), NumberType_Int32);
 
-    if (numGhosts && IsValidEdict(g_ghostEntity)) {
-        // TODO: NT only cares about the first ghost but we can add a loop here if we want to improve that
+    Address capZoneList = view_as<Address>(LoadFromAddress(view_as<Address>(0x22542734), NumberType_Int32));
 
-        // TODO: Couldn't figure out how to get carrier's team from memory, so storing ghost index in OnCreateEntity
-        // Address ghostList = view_as<Address>(LoadFromAddress(view_as<Address>(0x225443AC), NumberType_Int32));
-        // Address p_ghost = LoadFromAddress(ghostList, NumberType_Int32);
-        // Address p_owner = LoadFromAddress(p_ghost + view_as<Address>(0x1EC), NumberType_Int32);
-        // if (p_owner > -1) {
-        //     int team = LoadFromAddress(p_owner + view_as<Address>(0x208), NumberType_Int32);
-        //     PrintToServer("owner: %d, team: %d", p_owner, team);  // Garbage?
-        // }
+    int numCaps = 0;
+    for (int client = 1; client <= MaxClients; client++) {
+        if (numCaps >= numGhosts) {
+            break;
+        }
 
-        int carrier = GetEntPropEnt(g_ghostEntity, Prop_Data, "m_hOwnerEntity");
-        if (IsValidClient(carrier)) {
-            int carryingTeam = GetClientTeam(carrier);
-            float ghostOrigin[3];
-            GetClientAbsOrigin(carrier, ghostOrigin);
+        if (!IsClientInGame(client) || !IsGhostCarrier(client)) {
+            continue;
+        }
 
-            Address capZoneList = view_as<Address>(LoadFromAddress(view_as<Address>(0x22542734), NumberType_Int32));
-            for (int i = 0; i < numCapZones; i++) {
-                Address capZone = view_as<Address>(LoadFromAddress(capZoneList + view_as<Address>(i * 4), NumberType_Int32));
-                int m_OwningTeamNumber = LoadFromAddress(capZone + view_as<Address>(0x360), NumberType_Int32);
-                if (carryingTeam == m_OwningTeamNumber) {
-                    float x = view_as<float>(LoadFromAddress(capZone + view_as<Address>(0x354), NumberType_Int32));
-                    float y = view_as<float>(LoadFromAddress(capZone + view_as<Address>(0x358), NumberType_Int32));
-                    float z = view_as<float>(LoadFromAddress(capZone + view_as<Address>(0x35C), NumberType_Int32));
-                    x = x - ghostOrigin[0];
-                    y = y - ghostOrigin[1];
-                    z = z - ghostOrigin[2];
-                    float distance = SquareRoot(x*x + y*y + z*z);
-                    int m_Radius = LoadFromAddress(capZone + view_as<Address>(0x364), NumberType_Int32);
-                    if (distance <= m_Radius) {
-                        // Announce capper
-                        GameRules_SetProp("m_iMVP", carrier);
-                        RewardWin(carryingTeam, true);
-                        if (carryingTeam == TEAM_JINRAI) {
-                            EndRound(GAMEHUD_JINRAI);
-                        } else {
-                            EndRound(GAMEHUD_NSF);
-                        }
-                        return true;
+        int carryingTeam = GetClientTeam(client);
+        float ghostOrigin[3];
+        GetClientAbsOrigin(client, ghostOrigin);
+
+        for (int i = 0; i < numCapZones; i++) {
+            Address capZone = view_as<Address>(LoadFromAddress(capZoneList + view_as<Address>(i * 4), NumberType_Int32));
+            int m_OwningTeamNumber = LoadFromAddress(capZone + view_as<Address>(0x360), NumberType_Int32);
+            if (carryingTeam == m_OwningTeamNumber) {
+                float x = view_as<float>(LoadFromAddress(capZone + view_as<Address>(0x354), NumberType_Int32));
+                float y = view_as<float>(LoadFromAddress(capZone + view_as<Address>(0x358), NumberType_Int32));
+                float z = view_as<float>(LoadFromAddress(capZone + view_as<Address>(0x35C), NumberType_Int32));
+                x = x - ghostOrigin[0];
+                y = y - ghostOrigin[1];
+                z = z - ghostOrigin[2];
+                float distance = SquareRoot(x*x + y*y + z*z);
+                int m_Radius = LoadFromAddress(capZone + view_as<Address>(0x364), NumberType_Int32);
+                if (distance <= m_Radius) {
+                    // Announce capper
+                    GameRules_SetProp("m_iMVP", client);
+                    RewardWin(carryingTeam, true);
+                    if (carryingTeam == TEAM_JINRAI) {
+                        EndRound(GAMEHUD_JINRAI);
+                    } else {
+                        EndRound(GAMEHUD_NSF);
                     }
+                    return true;
                 }
             }
         }
+        numCaps++;
     }
+
+    // Address ghostList = view_as<Address>(LoadFromAddress(view_as<Address>(0x225443AC), NumberType_Int32));
+    // Address p_ghost = LoadFromAddress(ghostList, NumberType_Int32);
+    // Address p_owner = LoadFromAddress(p_ghost + view_as<Address>(0x1EC), NumberType_Int32);
+    // if (p_owner > -1) {
+    //     int team = LoadFromAddress(p_owner + view_as<Address>(0x208), NumberType_Int32);
+    //     PrintToServer("owner: %d, team: %d", p_owner, team);  // Garbage?
+    // }
+
     return false;
 }
 


### PR DESCRIPTION
Use game's player class method for checking whether that player is a ghost carrier (internally calls
`CBaseCombatCharacter__Weapon_OwnsThisType` with "weapon_ghost"). This allows for removing the requirement to track specific entity state via OnEntityCreated.

Also set up looping structure for >1 ghosts, although that case might require some special handling if it's actually explored.

Also unify whitespace indent as 4 spaces for places where tab was used.

## perf
Since this gets called somewhat often, here's some quick unscientific perf testing, too. TL;DR it doesn't seem there's any meaningful difference in terms of performance. Avg cost per frame is well within the "thousandth of a millisecond" range.

Before this PR:
```
******** BEGIN VPROF REPORT ********
-- Summary --
107995 frames sampled for 226.90 seconds
Average 475.96 fps, 2.10 ms per frame
Peak 83.33 ms frame
99 pct of time accounted for

-- Hierarchical Call Graph --
       Sum (ms)         Avg Time/Frame (ms)     Avg Time/Call (ms)
[ func+child   func ]  [ func+child   func ]  [ func+child   func ]  Count   Peak
  ---------- ------      ---------- ------      ---------- ------   ------ ------
     173.863 173.86           0.002   0.00           0.020   0.02     8724   0.76 nt_wincond.smx::.9932.CheckWinCondition


-- Profile scopes sorted by time (including children) --
  Scope                                                      Calls Calls/Frame  Time+Child    Pct        Time    Pct   Avg/Frame    Avg/Call Avg-NoChild        Peak
  ---------------------------------------------------- ----------- ----------- ----------- ------ ----------- ------ ----------- ----------- ----------- -----------
               nt_wincond.smx::.9932.CheckWinCondition        8724       0.081     173.863  0.08%     173.863  0.08%       0.002       0.020       0.020       0.763
```

After:
```
******** BEGIN VPROF REPORT ********
-- Summary --
26753 frames sampled for 53.61 seconds
Average 499.00 fps, 2.00 ms per frame
Peak 14.28 ms frame
99 pct of time accounted for

-- Hierarchical Call Graph --
       Sum (ms)         Avg Time/Frame (ms)     Avg Time/Call (ms)
[ func+child   func ]  [ func+child   func ]  [ func+child   func ]  Count   Peak
  ---------- ------      ---------- ------      ---------- ------   ------ ------
      70.215  70.22           0.003   0.00           0.013   0.01     5338   0.19  |  |  |  nt_wincond.smx::.9920.CheckWinCondition


-- Profile scopes sorted by time (including children) --
  Scope                                                      Calls Calls/Frame  Time+Child    Pct        Time    Pct   Avg/Frame    Avg/Call Avg-NoChild        Peak
  ---------------------------------------------------- ----------- ----------- ----------- ------ ----------- ------ ----------- ----------- ----------- -----------
               nt_wincond.smx::.9920.CheckWinCondition        5338       0.200      70.215  0.13%      70.215  0.13%       0.003       0.013       0.013       0.194
```