### PR TITLE
Added two cvars for further control of xp reward and assisting log parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,15 @@ Whether dead players should receive the ghost cap reward.
 0 = Disabled (Default)  
 1 = Enabled  
 
+_sm_nt_wincond_ghost_hold_reward_  
+Whether the ghost holder should get an extra 1 xp on an elimination win for their team.  
+0 = Disabled (Default)  
+1 = Enabled  
+
 ## Changelog
+
+### 0.0.12
+* Added new cvar to determine whether or not to award an extra xp point to the ghost holder when their team wins by elimination.
 
 ### 0.0.11
 * Fix issue where tiebreaker would always go to Jinrai in ATK mode.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ Whether the ghost holder should get an extra 1 xp on an elimination win for thei
 0 = Disabled (Default)  
 1 = Enabled  
 
+_sm_nt_wincond_round_end_logging_  
+Whether round end result is logged.  
+0 = Disabled  
+1 = Enabled (Default) 
+
 ## Changelog
+
+### 0.0.13
+* Added new cvar to determine whether round end result is logged, such as Tie, NSF win or Jinrai win to assist in log parsing.
 
 ### 0.0.12
 * Added new cvar to determine whether or not to award an extra xp point to the ghost holder when their team wins by elimination.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Whether dead players should receive the ghost cap reward.
 _sm_nt_wincond_ghost_hold_reward_  
 Whether the ghost holder should get an extra 1 xp on an elimination win for their team.  
 0 = Disabled (Default)  
-1 = Enabled  
+1 = Enabled (Vanilla)  
 
 _sm_nt_wincond_round_end_logging_  
 Whether round end result is logged.  

--- a/addons/sourcemod/scripting/nt_wincond.sp
+++ b/addons/sourcemod/scripting/nt_wincond.sp
@@ -5,7 +5,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION "0.0.11"
+#define PLUGIN_VERSION "0.0.12"
 
 #define GAMEHUD_TIE 3
 #define GAMEHUD_JINRAI 4
@@ -30,6 +30,7 @@ ConVar g_cvConsolationRounds;
 ConVar g_cvSurvivorBonus;
 ConVar g_cvGhostReward;
 ConVar g_cvGhostRewardDead;
+ConVar g_cvGhostHoldReward;
 
 ConVar g_cvHalfTimeEnabled;
 ConVar g_cvRoundLimit;
@@ -51,6 +52,7 @@ public void OnPluginStart() {
     g_cvSurvivorBonus = CreateConVar("sm_nt_wincond_survivor_bonus", "1", "Whether survivors on the winning team should receive extra xp. Note that disabling this will treat everyone as alive when rewarding ghost caps.", _, true, 0.0, true, 1.0);
     g_cvGhostReward = CreateConVar("sm_nt_wincond_ghost_reward", "0", "Determines how much xp to reward for a ghost cap.", _, true, 0.0); 
     g_cvGhostRewardDead = CreateConVar("sm_nt_wincond_ghost_reward_dead", "0", "Whether dead players should receive the ghost cap reward.", _, true, 0.0, true, 1.0);
+    g_cvGhostHoldReward = CreateConVar("sm_nt_wincond_ghost_hold_reward", "0", "Whether the ghost holder should get an extra 1 xp on an elimination win for their team.", _, true, 0.0, true, 1.0);
 
     AutoExecConfig();
 }
@@ -171,7 +173,7 @@ void RewardWin(int team, bool ghostCapped = false) {
                     if (g_cvSurvivorBonus.BoolValue && !IsPlayerDead(i)) {
                         xp++; // +1 for staying alive
                     }
-                    if (IsPlayerCarryingGhost(i)) {
+                    if (g_cvGhostHoldReward.BoolValue && IsPlayerCarryingGhost(i)) {
                         xp++; // +1 for carrying ghost
                     }
                 }

--- a/addons/sourcemod/scripting/nt_wincond.sp
+++ b/addons/sourcemod/scripting/nt_wincond.sp
@@ -123,7 +123,7 @@ void EndRound(int gameHud) {
     GameRules_SetProp("m_iGameState", GAMESTATE_ROUND_OVER);
     GameRules_SetPropFloat("m_fRoundTimeLeft", 15.0);
 	
-    if(g_cvRoundEndLogging.BoolValue) {
+    if (g_cvRoundEndLogging.BoolValue) {
         if(gameHud == GAMEHUD_TIE) {
             LogToGame("[WinCond] The round was a Tie");
         } else {

--- a/addons/sourcemod/scripting/nt_wincond.sp
+++ b/addons/sourcemod/scripting/nt_wincond.sp
@@ -5,7 +5,7 @@
 #pragma semicolon 1
 #pragma newdecls required
 
-#define PLUGIN_VERSION "0.0.12"
+#define PLUGIN_VERSION "0.0.13"
 
 #define GAMEHUD_TIE 3
 #define GAMEHUD_JINRAI 4
@@ -31,6 +31,7 @@ ConVar g_cvSurvivorBonus;
 ConVar g_cvGhostReward;
 ConVar g_cvGhostRewardDead;
 ConVar g_cvGhostHoldReward;
+ConVar g_cvRoundEndLogging;
 
 ConVar g_cvHalfTimeEnabled;
 ConVar g_cvRoundLimit;
@@ -53,7 +54,8 @@ public void OnPluginStart() {
     g_cvGhostReward = CreateConVar("sm_nt_wincond_ghost_reward", "0", "Determines how much xp to reward for a ghost cap.", _, true, 0.0); 
     g_cvGhostRewardDead = CreateConVar("sm_nt_wincond_ghost_reward_dead", "0", "Whether dead players should receive the ghost cap reward.", _, true, 0.0, true, 1.0);
     g_cvGhostHoldReward = CreateConVar("sm_nt_wincond_ghost_hold_reward", "0", "Whether the ghost holder should get an extra 1 xp on an elimination win for their team.", _, true, 0.0, true, 1.0);
-
+    g_cvRoundEndLogging = CreateConVar("sm_nt_wincond_round_end_logging", "1", "Whether round end result is logged.", _, true, 0.0, true, 1.0);
+	
     AutoExecConfig();
 }
 
@@ -120,6 +122,14 @@ void EndRound(int gameHud) {
     GameRules_SetProp("m_iGameHud", gameHud);
     GameRules_SetProp("m_iGameState", GAMESTATE_ROUND_OVER);
     GameRules_SetPropFloat("m_fRoundTimeLeft", 15.0);
+	
+    if(g_cvRoundEndLogging.BoolValue) {
+        if(gameHud == GAMEHUD_TIE) {
+            LogToGame("[WinCond] The round was a Tie");
+        } else {
+            LogToGame("[WinCond] Team %s has won the round", gameHud == GAMEHUD_JINRAI ? "Jinrai" : "NSF");
+        }
+    }
 }
 
 int RankUp(int xp) {


### PR DESCRIPTION
**sm_nt_wincond_ghost_hold_reward**  
Controls if a player will get an xp point for having the ghost held on an elimination win. Defaults to 0 (disabled) for now as I believe this a cryptic and illogical mechanic, only ever used by those with niche knowledge of the game to pickup the ghost at the last second as opposed to actually rewarding ghost play. Kind of like the tiebreaker setting, serverops can revert this to the default game behaviour if they wish in the config files.

**sm_nt_wincond_round_end_logging**
This will assist log parsing for statistics and defaults to 1 (enabled).